### PR TITLE
Revert "Using gcc -m32 instead of i686 gcc"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 ARCH        := i386
 
-CC          := gcc -m32 # i686-linux-gnu-gcc-8
-AS          := gcc -m32 -x assembler -c # i686-linux-gnu-as
-CCFLAGS     := -g -ffreestanding -nostdlib -nostartfiles -nolibc -Wall -Wextra -Werror -Isrc -Isrc/libc -fno-pie -fno-stack-protector # -lgcc
-LDFLAGS     := -g -ffreestanding -nostdlib -nostartfiles -nolibc
+CC          := i686-linux-gnu-gcc-8
+AS          := i686-linux-gnu-as
+CCFLAGS     := -g -ffreestanding -Wall -Wextra -Werror -Isrc -Isrc/libc -lgcc -nostartfiles -fno-pie
+LDFLAGS     := -g -ffreestanding -nostdlib -nostartfiles
 
 # Directories
 BUILD_DIR   := build

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Development is sometimes streamed on [my Twitch channel](https://www.twitch.tv/n
 
 ## Dependencies
 
-- gcc
+- i686 gcc8
 - make
 - qemu (for testing and debugging)
 - xorriso (optional, only needed for ISO creation)
@@ -21,7 +21,7 @@ If you're using and Ubuntu / Debian based OS you can just run these commands to 
 
 ```sh
 sudo apt update
-sudo apt install gcc make qemu xorriso
+sudo apt install gcc-8-i686-linux-gnu make qemu xorriso
 ```
 
 ## Building


### PR DESCRIPTION
Reverts Nufflee/EPIC#17

Literally moved from good practice of using cross compiler to terrible practice of using system gcc and praying that it works, passing dumb things like `-nolibc` which isn't even a flag, etc.